### PR TITLE
Unfreeze options hash #4130

### DIFF
--- a/lib/ncs_navigator/warehouse/cli.rb
+++ b/lib/ncs_navigator/warehouse/cli.rb
@@ -4,6 +4,12 @@ require 'thor'
 
 module NcsNavigator::Warehouse
   class CLI < Thor
+
+    def initialize(args=[], options={}, config={})
+      super
+      @options = @options.dup
+    end
+
     class_option :quiet, :type => :boolean, :aliases => %w(-q),
       :desc => 'Suppress the status messages printed to standard error'
     class_option 'config', :type => :string, :aliases => %w(-c),


### PR DESCRIPTION
Recent addtions to `CLI` attempt to modify the frozen `@options` hash.  It breaks `emit-xml`.
