### PR TITLE
fix soft_validations for required fields #4315

### DIFF
--- a/ci-exec.sh
+++ b/ci-exec.sh
@@ -2,7 +2,7 @@
 
 export NCS_NAVIGATOR_ENV=ci
 
-BUNDLER_VERSION=1.2.0
+BUNDLER_VERSION=1.3.5
 GEMSET=ncs_mdes_warehouse
 
 if [ -z $CI_RUBY ]; then

--- a/lib/ncs_navigator/warehouse/data_mapper_patches.rb
+++ b/lib/ncs_navigator/warehouse/data_mapper_patches.rb
@@ -45,3 +45,16 @@ module DataMapper::Inflector
     lower_case_and_underscored_word
   end
 end
+
+# TODO: add/verify there are specs to ensure this does not break the
+#       behavior of mdes-wh without --soft_validations
+#
+# This hack is added to get around DataMapper validating :required =>
+# true in dm-core. With dm-validations :required => true is also
+# validated but the validation in dm-core cannot be disabled using
+# save! (or any other known method)
+class DataMapper::Property
+  def valid?(*args)
+    true
+  end
+end

--- a/spec/ncs_navigator/warehouse/transformers/enum_transformer_soft_validations_spec.rb
+++ b/spec/ncs_navigator/warehouse/transformers/enum_transformer_soft_validations_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+require 'ncs_navigator/warehouse/data_mapper'
+
+module NcsNavigator::Warehouse::Transformers
+  describe EnumTransformer do
+    describe '#transform' do
+      context 'soft_validations', :use_database, :modifies_warehouse_state do
+
+        class Sample
+          include ::DataMapper::Resource
+
+          property :psu_id, String
+          property :recruit_type, String, :format => /^\d$/
+          property :id, Integer, :key => true
+          property :name, String, :required => true
+        end
+
+        before(:all) do
+          DataMapper.finalize
+        end
+
+        let(:records) {[Sample.new(:id => 1, :psu_id => '20000030', :name => 'One'),
+                        Sample.new(:id => 2, :psu_id => '20000030', :name => 'Two'),
+                        Sample.new(:id => 3, :psu_id => '20000030', :name => 'Three')
+                       ]}
+        let(:transformer) { EnumTransformer.new(spec_config.tap{|c|c.soft_validations = true}, records) }
+        let(:transform_status) { NcsNavigator::Warehouse::TransformStatus.memory_only('test') }
+
+        it 'saves invalid records but still records validation errors' do
+          records[2].recruit_type = 'H'
+          records[2].dirty?.should == true
+          records[2].valid?.should == false
+          transformer.transform(transform_status)
+          transform_status.transform_errors.size.should == 1
+          records[2].dirty?.should == false
+        end
+
+        context "in combination with drop_all_null_constraints" do
+
+          around(:each) do |ex|
+            NcsNavigator::Warehouse::Spec.database_initializer.replace_schema
+            ex.run
+            NcsNavigator::Warehouse::Spec.database_initializer.replace_schema
+          end
+
+          it 'saves null records with drop_all_null_constraints' do
+            NcsNavigator::Warehouse::Spec.database_initializer.drop_all_null_constraints(:working)
+            records[2].name = nil
+            records[2].dirty?.should == true
+            records[2].valid?.should == false
+            transformer.transform(transform_status)
+            transform_status.transform_errors.size.should == 1
+            records[2].dirty?.should == false
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ncs_navigator/warehouse/transformers/enum_transformer_soft_validations_spec.rb
+++ b/spec/ncs_navigator/warehouse/transformers/enum_transformer_soft_validations_spec.rb
@@ -29,29 +29,23 @@ module NcsNavigator::Warehouse::Transformers
 
         it 'saves invalid records but still records validation errors' do
           records[2].recruit_type = 'H'
-          records[2].dirty?.should == true
-          records[2].valid?.should == false
+          records[2].should be_dirty
+          records[2].should_not be_valid
           transformer.transform(transform_status)
           transform_status.transform_errors.size.should == 1
-          records[2].dirty?.should == false
+          records[2].should_not be_dirty
         end
 
         context "in combination with drop_all_null_constraints" do
-
-          around(:each) do |ex|
-            NcsNavigator::Warehouse::Spec.database_initializer.replace_schema
-            ex.run
-            NcsNavigator::Warehouse::Spec.database_initializer.replace_schema
-          end
-
+          before(:all) {NcsNavigator::Warehouse::Spec.database_initializer.drop_all_null_constraints(:working)}
+          after (:all) {NcsNavigator::Warehouse::Spec.database_initializer.replace_schema}
           it 'saves null records with drop_all_null_constraints' do
-            NcsNavigator::Warehouse::Spec.database_initializer.drop_all_null_constraints(:working)
             records[2].name = nil
-            records[2].dirty?.should == true
-            records[2].valid?.should == false
+            records[2].should be_dirty
+            records[2].should_not be_valid
             transformer.transform(transform_status)
             transform_status.transform_errors.size.should == 1
-            records[2].dirty?.should == false
+            records[2].should_not be_dirty
           end
         end
       end

--- a/spec/ncs_navigator/warehouse/transformers/enum_transformer_spec.rb
+++ b/spec/ncs_navigator/warehouse/transformers/enum_transformer_spec.rb
@@ -309,7 +309,7 @@ module NcsNavigator::Warehouse::Transformers
           err = transform_status.transform_errors.first
           err.model_class.should == Sample.to_s
           err.record_id.should == '2'
-          err.message.should =~ /^Could not save valid record/
+          err.message.should =~ /^Could not save record/
         end
 
         it 'saves the saveable instances' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,8 +71,9 @@ RSpec.configure do |config|
   # This interferes with global state (DM's connection setup), so we need
   # to reconnect for each :use_database group to correct.
   config.before(:all, :use_database) do
-    init = NcsNavigator::Warehouse::DatabaseInitializer.new(spec_config)
-    init.set_up_repository(:both)
+    NcsNavigator::Warehouse::Spec.database_initializer(spec_config).tap do |db|
+      db.set_up_repository(:both)
+    end
   end
 
   config.after(:each, :use_database) do

--- a/spec/spec_warehouse_config.rb
+++ b/spec/spec_warehouse_config.rb
@@ -23,8 +23,8 @@ module NcsNavigator::Warehouse
       end
     end
 
-    def self.database_initializer
-      @database_initializer ||= DatabaseInitializer.new(configuration)
+    def self.database_initializer(config = self.configuration)
+      @database_initializer ||= DatabaseInitializer.new(config)
     end
   end
 end


### PR DESCRIPTION
dm-core AND dm-validations checks for :required => true fields. The
dm-core check cannot be disabled using save! so this disables it.

This also adds preliminary specs for soft_validations.
