### PR TITLE
Take transformer runs out of transactions.  #4315.

### DIFF
--- a/lib/ncs_navigator/warehouse/transform_load.rb
+++ b/lib/ncs_navigator/warehouse/transform_load.rb
@@ -33,25 +33,12 @@ module NcsNavigator::Warehouse
 
           build_status_for(transformer, position).tap do |status|
             begin
-              TransformStatus.transaction do
-                if repo.adapter.to_s =~ /Postgres/
-                  repo.adapter.execute("SET LOCAL synchronous_commit TO OFF")
-                end
-                begin
-                  transformer.transform(status)
-                rescue => e
-                  shell.say_line("\nTransform failed. (See log for more detail.)")
-                  msg = "Transform failed. #{e.class}: #{e}\n#{stringify_trace(e.backtrace)}"
-                  log.error(msg)
-                  status.add_error(msg)
-                end
-              end
-            rescue DataObjects::IntegrityError => e
-              shell.say_line(
-                "\nTransform failed with data integrity error. (See log for more detail.)")
-              log.error(
-                "Transform failed with data integrity error: #{e}.\n#{stringify_trace(e.backtrace)}")
-              status.add_error("Transform failed with data integrity error: #{e}.")
+              transformer.transform(status)
+            rescue => e
+              shell.say_line("\nTransform failed. (See log for more detail.)")
+              msg = "Transform failed. #{e.class}: #{e}\n#{stringify_trace(e.backtrace)}"
+              log.error(msg)
+              status.add_error(msg)
             end
             status.end_time = Time.now
             unless status.save


### PR DESCRIPTION
We are currently running a (mad?) experiment to see if we can relax MDES
constraints while still submitting data to the VDR.  (It's understood
that the generated data will not pass schema validations in the
Workbench.)

To make this work, we need to relax all DM validations _and_ disable the
per-transformer transaction, as it's entirely possible that some errors
that would ordinarily be caught by validations will now interact badly
with other non-(non-NULL) constraints.  (Column length checks, for
example.)  By removing the per-transformer transaction, we ensure that
i.e. invalid INSERTs are not ignored until the end of the transaction,
because that outer transaction has been removed.
