### PR TITLE
Correct options handling #9723

### DIFF
--- a/lib/ncs_navigator/warehouse/xml_emitter.rb
+++ b/lib/ncs_navigator/warehouse/xml_emitter.rb
@@ -106,7 +106,7 @@ XML
     #   `:filters=>nil` in the options.
     def initialize(config, filename, options={})
       @configuration = config
-      @zip = options.has_key?(:zip) ? options[:zip] : true
+      @zip = options.has_key?('zip') ? options['zip'] : true
 
       @xml_files = determine_files_to_create(filename, options)
 
@@ -116,8 +116,8 @@ XML
         @content_enumerator = options[:content]
       else
         filter_names =
-          if options.has_key?(:filters)
-            options[:filters] ? options[:filters] : []
+          if options.has_key?('filters')
+            options['filters'] ? options['filters'] : []
           else
             [config.default_xml_filter_set].compact
           end

--- a/spec/ncs_navigator/warehouse/transformers/enum_transformer_spec.rb
+++ b/spec/ncs_navigator/warehouse/transformers/enum_transformer_spec.rb
@@ -309,7 +309,7 @@ module NcsNavigator::Warehouse::Transformers
           err = transform_status.transform_errors.first
           err.model_class.should == Sample.to_s
           err.record_id.should == '2'
-          err.message.should =~ /^Could not save record/
+          err.message.should =~ /^Could not save [a-z ]*record/
         end
 
         it 'saves the saveable instances' do

--- a/spec/ncs_navigator/warehouse/xml_emitter_spec.rb
+++ b/spec/ncs_navigator/warehouse/xml_emitter_spec.rb
@@ -5,7 +5,7 @@ require 'zip/zip'
 module NcsNavigator::Warehouse
   describe XmlEmitter, :use_mdes do
     let(:filename) { tmpdir + 'export.xml' }
-    let(:options) { { :zip => false } }
+    let(:options) { { 'zip' => false } }
     let(:emitter) { XmlEmitter.new(spec_config, filename, options) }
     let(:xml) {
       emitter.emit_xml
@@ -246,19 +246,19 @@ module NcsNavigator::Warehouse
             end
 
             it 'is used when there are no filters in the options' do
-              options.delete(:filters)
+              options.delete('filters')
 
               person_names.should == %w(nitneuQ reivaX)
             end
 
             it 'is not used when a different filter is in the options' do
-              options[:filters] = ['upcaser']
+              options['filters'] = ['upcaser']
 
               person_names.should == %w(QUENTIN XAVIER)
             end
 
             it 'is not used when explicitly disabled' do
-              options[:filters] = nil
+              options['filters'] = nil
 
               person_names.should == %w(Quentin Xavier)
             end
@@ -266,19 +266,19 @@ module NcsNavigator::Warehouse
 
           describe 'when there is no default XML filter in the configuration' do
             it 'applies no filters when none are specified' do
-              options.delete(:filters)
+              options.delete('filters')
 
               person_names.should == %w(Quentin Xavier)
             end
 
             it 'applies no filters when an absence of filters is specified' do
-              options[:filters] = nil
+              options['filters'] = nil
 
               person_names.should == %w(Quentin Xavier)
             end
 
             it 'applies specified filters, if any' do
-              options[:filters] = ['upcaser', 'reverser']
+              options['filters'] = ['upcaser', 'reverser']
 
               person_names.should == %w(NITNEUQ REIVAX)
             end
@@ -345,12 +345,12 @@ module NcsNavigator::Warehouse
         end
 
         it 'exists if explicitly requested' do
-          options[:zip] = true
+          options['zip'] = true
           actual.should be_readable
         end
 
         it 'does not exist when excluded' do
-          options[:zip] = false
+          options['zip'] = false
           actual.exist?.should be_false
         end
       end


### PR DESCRIPTION
New version of Thor options hash switched to strings.  This prevented it filters in emit-xml class from being recognized properly.
